### PR TITLE
Make transparent icons non-interactable (for real this time); Option to always show aetherytes in front of other icons on the big map

### DIFF
--- a/QuestAWAY/Configuration.cs
+++ b/QuestAWAY/Configuration.cs
@@ -21,6 +21,7 @@ namespace QuestAWAY
         public string CustomPathes = "";
         public bool HideFateCircles = false;
         public bool HideAreaMarkers = false;
+        public bool AetheryteInFront = false;
 
         [NonSerialized]
         private QuestAWAY p;

--- a/QuestAWAY/MemoryReplacer.cs
+++ b/QuestAWAY/MemoryReplacer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Dalamud;
+using Dalamud.Logging;
+
+namespace QuestAWAY;
+
+public class MemoryReplacer : IDisposable
+{
+    public IntPtr Address { get; private set; } = IntPtr.Zero;
+    private readonly byte[] newBytes;
+    private readonly byte[] oldBytes;
+    public bool IsEnabled { get; private set; } = false;
+    public bool IsValid => Address != IntPtr.Zero;
+
+    public MemoryReplacer(string sig, byte[] bytes, bool startEnabled = false)
+    {
+        var addr = IntPtr.Zero;
+        try
+        {
+            addr = Svc.SigScanner.ScanModule(sig);
+        }
+        catch
+        {
+            PluginLog.LogError($"Failed to find signature {sig}");
+        }
+
+        if (addr == IntPtr.Zero) return;
+
+        Address = addr;
+        newBytes = bytes;
+        SafeMemory.ReadBytes(addr, bytes.Length, out oldBytes);
+
+        if (startEnabled)
+            Enable();
+    }
+
+    public void Enable()
+    {
+        if (!IsValid) return;
+        SafeMemory.WriteBytes(Address, newBytes);
+        IsEnabled = true;
+    }
+
+    public void Disable()
+    {
+        if (!IsValid) return;
+        SafeMemory.WriteBytes(Address, oldBytes);
+        IsEnabled = false;
+    }
+
+    public void Toggle()
+    {
+        if (!IsEnabled)
+            Enable();
+        else
+            Disable();
+    }
+
+    public void Dispose()
+    {
+        if (IsEnabled)
+            Disable();
+    }
+}

--- a/QuestAWAY/PluginAddressResolver.cs
+++ b/QuestAWAY/PluginAddressResolver.cs
@@ -39,9 +39,10 @@ internal class PluginAddressResolver : BaseAddressResolver
     private const string AddonAreaMapOnRefresh = "4C 8B DC 55 56 41 56 41 57 49 8D 6B A1";
     private const string AddonNaviMapOnUpdate = "48 8B C4 55 48 81 EC ?? ?? ?? ?? F6 81";
 
-    public IntPtr MapAreaSetVisibilityAndRotationAddress { get; private set; }
+    // change 0F 95 SETNZ into 0F 94 SETZ 
+    public const string AreaMapCtrl = "0F 95 C0 3A 83 ?? ?? ?? ?? 74 ?? 83 8B";
+
     public IntPtr AddonAreaMapOnUpdateAddress { get; private set; }
-    public IntPtr AddonAreaMapOnRefreshAddress { get; private set; }
     public IntPtr AddonNaviMapOnUpdateAddress { get; private set; }
     public IntPtr NaviMapOnMouseMoveAddress { get; private set; }
     public IntPtr CheckAtkCollisionNodeIntersectAddress { get; private set; }
@@ -50,18 +51,14 @@ internal class PluginAddressResolver : BaseAddressResolver
     /// <inheritdoc/>
     protected override void Setup64Bit(SigScanner scanner)
     {
-        MapAreaSetVisibilityAndRotationAddress = scanner.ScanText(MapAreaSetVisibilityAndRotation);
         AddonAreaMapOnUpdateAddress = scanner.ScanText(AddonAreaMapOnUpdate);
-        AddonAreaMapOnRefreshAddress = scanner.ScanText(AddonAreaMapOnRefresh);
         AddonNaviMapOnUpdateAddress = scanner.ScanText(AddonNaviMapOnUpdate);
         NaviMapOnMouseMoveAddress = scanner.ScanText(NaviMapOnMouseMove);
         CheckAtkCollisionNodeIntersectAddress = scanner.ScanText(CheckAtkCollisionNodeIntersect);
         AreaMapOnMouseMoveAddress = scanner.ScanText(AreaMapOnMouseMove);
 
         PluginLog.Verbose("===== QuestAWAY =====");
-        PluginLog.Verbose($"{nameof(MapAreaSetVisibilityAndRotationAddress)} {MapAreaSetVisibilityAndRotationAddress:X}");
         PluginLog.Verbose($"{nameof(AddonAreaMapOnUpdateAddress)} {AddonAreaMapOnUpdateAddress:X}");
-        PluginLog.Verbose($"{nameof(AddonAreaMapOnRefreshAddress)} {AddonAreaMapOnRefreshAddress:X}");
         PluginLog.Verbose($"{nameof(AddonNaviMapOnUpdateAddress)} {AddonNaviMapOnUpdateAddress:X}");
         PluginLog.Verbose($"{nameof(NaviMapOnMouseMoveAddress)} {NaviMapOnMouseMoveAddress:X}");
         PluginLog.Verbose($"{nameof(CheckAtkCollisionNodeIntersectAddress)} {CheckAtkCollisionNodeIntersectAddress:X}");

--- a/QuestAWAY/PluginAddressResolver.cs
+++ b/QuestAWAY/PluginAddressResolver.cs
@@ -29,34 +29,42 @@ internal class PluginAddressResolver : BaseAddressResolver
     
     // in NaviMapOnMouseMove function, there's 3 ifs. this function is the second condition in all of them
     private const string CheckAtkCollisionNodeIntersect = "E8 ?? ?? ?? ?? 84 C0 75 B9";
+
+    // to update this sig:
+    // from AreaMap ReceiveEvent, enter the function called when a2==5 and a3==20
+    // the the only unnamed function there
+    private const string AreaMapOnMouseMove = "48 8B C4 53 56 48 83 EC 78";
     
     private const string AddonAreaMapOnUpdate = "48 8B C4 48 89 48 08 55 57";
     private const string AddonAreaMapOnRefresh = "4C 8B DC 55 56 41 56 41 57 49 8D 6B A1";
     private const string AddonNaviMapOnUpdate = "48 8B C4 55 48 81 EC ?? ?? ?? ?? F6 81";
 
     public IntPtr MapAreaSetVisibilityAndRotationAddress { get; private set; }
-    public IntPtr ClientUiAddonAreaMapOnUpdateAddress { get; private set; }
-    public IntPtr ClientUiAddonAreaMapOnRefreshAddress { get; private set; }
+    public IntPtr AddonAreaMapOnUpdateAddress { get; private set; }
+    public IntPtr AddonAreaMapOnRefreshAddress { get; private set; }
     public IntPtr AddonNaviMapOnUpdateAddress { get; private set; }
     public IntPtr NaviMapOnMouseMoveAddress { get; private set; }
     public IntPtr CheckAtkCollisionNodeIntersectAddress { get; private set; }
+    public IntPtr AreaMapOnMouseMoveAddress { get; private set; }
 
     /// <inheritdoc/>
     protected override void Setup64Bit(SigScanner scanner)
     {
         MapAreaSetVisibilityAndRotationAddress = scanner.ScanText(MapAreaSetVisibilityAndRotation);
-        ClientUiAddonAreaMapOnUpdateAddress = scanner.ScanText(AddonAreaMapOnUpdate);
-        ClientUiAddonAreaMapOnRefreshAddress = scanner.ScanText(AddonAreaMapOnRefresh);
+        AddonAreaMapOnUpdateAddress = scanner.ScanText(AddonAreaMapOnUpdate);
+        AddonAreaMapOnRefreshAddress = scanner.ScanText(AddonAreaMapOnRefresh);
         AddonNaviMapOnUpdateAddress = scanner.ScanText(AddonNaviMapOnUpdate);
         NaviMapOnMouseMoveAddress = scanner.ScanText(NaviMapOnMouseMove);
         CheckAtkCollisionNodeIntersectAddress = scanner.ScanText(CheckAtkCollisionNodeIntersect);
+        AreaMapOnMouseMoveAddress = scanner.ScanText(AreaMapOnMouseMove);
 
         PluginLog.Verbose("===== QuestAWAY =====");
         PluginLog.Verbose($"{nameof(MapAreaSetVisibilityAndRotationAddress)} {MapAreaSetVisibilityAndRotationAddress:X}");
-        PluginLog.Verbose($"{nameof(ClientUiAddonAreaMapOnUpdateAddress)} {ClientUiAddonAreaMapOnUpdateAddress:X}");
-        PluginLog.Verbose($"{nameof(ClientUiAddonAreaMapOnRefreshAddress)} {ClientUiAddonAreaMapOnRefreshAddress:X}");
+        PluginLog.Verbose($"{nameof(AddonAreaMapOnUpdateAddress)} {AddonAreaMapOnUpdateAddress:X}");
+        PluginLog.Verbose($"{nameof(AddonAreaMapOnRefreshAddress)} {AddonAreaMapOnRefreshAddress:X}");
         PluginLog.Verbose($"{nameof(AddonNaviMapOnUpdateAddress)} {AddonNaviMapOnUpdateAddress:X}");
         PluginLog.Verbose($"{nameof(NaviMapOnMouseMoveAddress)} {NaviMapOnMouseMoveAddress:X}");
         PluginLog.Verbose($"{nameof(CheckAtkCollisionNodeIntersectAddress)} {CheckAtkCollisionNodeIntersectAddress:X}");
+        PluginLog.Verbose($"{nameof(AreaMapOnMouseMoveAddress)} {AreaMapOnMouseMoveAddress:X}");
     }
 }

--- a/QuestAWAY/QuestAWAY.cs
+++ b/QuestAWAY/QuestAWAY.cs
@@ -67,9 +67,14 @@ namespace QuestAWAY
             AreaMapOnMouseMoveHook.Dispose();
             CheckAtkCollisionNodeIntersectHook.Dispose();
             cfg.Save();
+
             cfg.Enabled = false;
+            reprocessNaviMap = true;
+            reprocessAreaMap = true;
+            ProcessMinimap((AtkUnitBase*)Svc.GameGui.GetAddonByName("_NaviMap", 1));
+            ProcessAreaMap((AtkUnitBase*)Svc.GameGui.GetAddonByName("AreaMap", 1));
+
             Svc.Commands.RemoveHandler("/questaway");
-            Tick(null);
             foreach (var t in textures.Values)
             {
                 t.Dispose();
@@ -181,10 +186,11 @@ namespace QuestAWAY
         {
             // runs when the area map is opened or changes areas
             var result = AddonAreaMapOnRefreshHook.Original(addonAreaMap, unk2, unk3);
-            if (reprocessAreaMap)
+            if ((cfg.Enabled && cfg.Bigmap) || reprocessAreaMap)
             {
                 ProfilingContinue();
                 ProcessAreaMap(addonAreaMap);
+                reprocessAreaMap = true;
                 ProfilingPause();
             }
 

--- a/QuestAWAY/QuestAWAY.cs
+++ b/QuestAWAY/QuestAWAY.cs
@@ -55,6 +55,9 @@ namespace QuestAWAY
         private readonly Hook<CheckAtkCollisionNodeIntersectDelegate> CheckAtkCollisionNodeIntersectHook;
         private readonly Hook<AreaMapOnMouseMoveDelegate> AreaMapOnMouseMoveHook;
 
+        public static readonly MemoryReplacer AreaMapCtrlAlwaysOn =
+            new(PluginAddressResolver.AreaMapCtrl, new byte[] { 0x0F, 0x94 });
+
         public void Dispose()
         {
             Svc.Framework.Update -= Tick;
@@ -65,6 +68,8 @@ namespace QuestAWAY
             AreaMapOnMouseMoveHook.Dispose();
             CheckAtkCollisionNodeIntersectHook.Dispose();
             cfg.Save();
+            
+            AreaMapCtrlAlwaysOn.Dispose();
 
             cfg.Enabled = false;
             reprocessNaviMap = true;
@@ -109,6 +114,9 @@ namespace QuestAWAY
             CheckAtkCollisionNodeIntersectHook.Disable();
             AddonNaviMapOnUpdateHook.Enable();
             AreaMapOnMouseMoveHook.Enable();
+            
+            if(cfg.AetheryteInFront)
+                AreaMapCtrlAlwaysOn.Enable();
 
             Svc.Framework.Update += Tick;
             Svc.PluginInterface.UiBuilder.Draw += Draw;
@@ -247,6 +255,8 @@ namespace QuestAWAY
                         ImGui.Checkbox("Hide icons on big map", ref cfg.Bigmap);
                         ImGui.Checkbox("Hide icons on minimap", ref cfg.Minimap);
                         ImGui.Checkbox("Display quick enable/disable on big map", ref cfg.QuickEnable);
+                        if(ImGui.Checkbox("Aetherytes always in front on big map", ref cfg.AetheryteInFront))
+                            AreaMapCtrlAlwaysOn.Toggle();
                         ImGui.Text("Additional pathes to hide (one per line, without _hr1 and .tex)");
                         ImGui.InputTextMultiline("##QAUSERADD", ref cfg.CustomPathes, 1000000, new Vector2(300f, 100f));
                         if (ImGui.CollapsingHeader("Developer settings"))


### PR DESCRIPTION
* back to using transparency instead of visibility, using a slight refactor of the old code
* make transparent map/minimap icons non-interactable
* avoid all the bugs that came from not being able to tell if the icon had been shown/hidden by the game or the plugin
* performance similar to other versions that use transparency
* BuildHiddenByteSet only when changes are made to the set of hidden icons
* add new option to always show aetherytes in front of other icons on the big map